### PR TITLE
fixed things causing failing tests in these documents

### DIFF
--- a/inst/tutorials/02-wrangling-A/tutorial.Rmd
+++ b/inst/tutorials/02-wrangling-A/tutorial.Rmd
@@ -28,7 +28,7 @@ options(tutorial.exercise.timelimit = 600,
 
 cces_filt <- cces %>%
   filter(ideology %in% c("Conservative", "Not Sure", 
-                        "Moderate", "Liberal"))
+                        "Moderate", "Liberal")) 
 ```
 
 <!-- DK: Put police data in primer.tutorials/inst/www and then adjut your link.  -->
@@ -87,7 +87,7 @@ x <- read_csv("https://raw.githubusercontent.com/lawanin/PA-policing-data/master
 ```{r str-2-hint, eval = FALSE}
 x <- read_csv("https://raw.githubusercontent.com/lawanin/PA-policing-data/master/philly-clean.csv", col_types = cols())  
 
-x %>% 
+x %>% %>% 
   select(..., ..., ..., ...)
 ```
 

--- a/inst/tutorials/02-wrangling-C/tutorial.Rmd
+++ b/inst/tutorials/02-wrangling-C/tutorial.Rmd
@@ -1599,7 +1599,7 @@ Within facet_wrap(), remember to put a ~ before the variable you want to facet b
 
 ```{r kenya8-hint-2, eval = FALSE}
 ... + 
-  facet_wrap(...) 
+  facet_wrap %>%  
 ```
 
 ### Exercise 9
@@ -1709,7 +1709,7 @@ We have provided you with the beginning of code for the last plot. Continue your
   mutate(age_groups = case_when(mean_age < 41.5  ~ "1",
                                      mean_age >= 41.5  ~ "2")) %>% 
   select(reg_byrv13, treatment, poverty_groups, age_groups) %>% 
-  drop_na() %>%
+  drop_na() 
 ```
 
 ```{r kenya13-hint, eval = FALSE}
@@ -1820,9 +1820,9 @@ kenya %>%
             poverty >= .43 & poverty < .49 ~ "3",
             poverty >= .49 ~ "4")) %>% 
   mutate(age_groups = case_when(mean_age < 41.5  ~ "1",
-                                     mean_age >= 41.5  ~ "2")) %>% 
+                                     mean_age >= 41.5  ~ "2")) %>%
   select(reg_byrv13, poverty_groups, age_groups) %>% 
-  drop_na() %>%
+  drop_na() 
 ```
 
 ```{r kenya17-hint, eval = FALSE}

--- a/inst/tutorials/03-data-API/tutorial.Rmd
+++ b/inst/tutorials/03-data-API/tutorial.Rmd
@@ -271,20 +271,15 @@ Recall that the `content()` call extracts the content from the response to the H
 The many Ms is this dataset's way of representing missing values. Within `read_csv()`, use the `na` argument to change all occurrences of the lone character `"M"` to `NA`.Save this output as an object named 'denver'. 
 
 ```{r query-10, exercise = TRUE}
+
+```
+
+```{r query-10-hint-1, eval = FALSE}
 GET(url = ...,
               query = list(...,
                            format = "comma")) %>% 
   content() %>% 
   read_csv(... , ...)
-
-```
-
-
-
-
-```{r query-10-hint, eval = FALSE}
-Make sure that you properly address NA values - see 
-the *Primer* for examples. 
 ```
 
 ### Exercise 10


### PR DESCRIPTION
when I run build test, I still get the following:

> checking for unstated dependencies in ‘tests’ ... WARNING
  'library' or 'require' call not declared from: ‘stringr’

> checking dependencies in R code ... NOTE
  Unexported objects imported by ':::' calls:
    ‘learnr:::get_all_state_objects’ ‘learnr:::read_request’
    ‘learnr:::submissions_from_state_objects’
    See the note in ?`:::` about the use of this operator.

0 errors ✓ | 1 warning x | 1 note x
Error: R CMD check found WARNINGs
Execution halted

Exited with status 1.