### PR TITLE
allow numbers as part of section id

### DIFF
--- a/R/check_current_tutorial.R
+++ b/R/check_current_tutorial.R
@@ -120,7 +120,7 @@ check_current_tutorial <- function(){
 
     possible_id_removed_prev <- gsub("\\{#(.*)\\}", "", l)
 
-    possible_id_removed <- gsub("[^a-zA-Z ]", "", possible_id_removed_prev)
+    possible_id_removed <- gsub("[^a-zA-Z0-9 ]", "", possible_id_removed_prev)
 
     lowercase_id <- tolower(trimws(possible_id_removed))
 


### PR DESCRIPTION
pointed out by Sophia

section names like: Object 1, Object 2
are previously simplified to the same id because numbers are ignored.

Fixed this error