### PR TITLE
Fix wording to match plot

### DIFF
--- a/inst/tutorials/024-wrangling-more-plots/tutorial.Rmd
+++ b/inst/tutorials/024-wrangling-more-plots/tutorial.Rmd
@@ -2094,7 +2094,7 @@ Let's create this unique circle graph
 
 ###
 
-This graph displays the popularity of the top male names in this data for the first five years of this study. 1880 - 1885.
+This graph displays the popularity of the top five male names in this data.
 
 
 ```{r}
@@ -2154,7 +2154,7 @@ Use `filter()` to get only the male names
 
 ### Exercise 8
 
-Now use `top_n()` to take the first five years of the study
+Now use `top_n()` to take the top five names for each year in the data
 
 ```{r more-babynames-8, exercise = TRUE}
 
@@ -2166,10 +2166,6 @@ Now use `top_n()` to take the first five years of the study
 ... |>
   top_n(n = ...)
 ```
-
-###
-
-Note this does not take every name from the 1880 - 1885, it takes the top names from that five year period.
 
 
 ### Exercise 9


### PR DESCRIPTION
In the circle bar graph, starting in exercise 5, the example graph shows the top 5 names for all years, but the instructions say the top 5 names from 1880-1885, so I changed the instructions to say top five names for each year.