### PR TITLE
Fix typo in variable name

### DIFF
--- a/inst/tutorials/025-census-data-i/tutorial.Rmd
+++ b/inst/tutorials/025-census-data-i/tutorial.Rmd
@@ -406,7 +406,7 @@ Notice the the GEOID column contains the FIPS code of the area the data covers. 
 
 Rather than using the `variables` argument, you can supply a table name to the `table` parameter in `get_acs()`; this will return data for every variable in that table. 
 
-Run `get_acs()` below setting `geography` to `"state"`, `table` to `"B001001"`, and `year` to `2020`
+Run `get_acs()` below setting `geography` to `"state"`, `table` to `"B01001"`, and `year` to `2020`
 
 ```{r getting-data-6, exercise = TRUE}
 


### PR DESCRIPTION
There is an extra zero in the ACS variable name.