### PR TITLE
**Very Minor** Fixes to Tutorial 9

### DIFF
--- a/inst/tutorials/091-five-parameters/tutorial.Rmd
+++ b/inst/tutorials/091-five-parameters/tutorial.Rmd
@@ -356,7 +356,7 @@ question_text(NULL,
 
 Create a Github repo called `tutorial-9`. Connect it to an new R Project called `tutorial-9`. Edit the `.gitignore` file to ignore the Rproj file.
 
-In the Console, run `tutorial.helpers::show_file(".gitignore")`. CP/CR.
+In the Console, run `library(tutorial.helpers)` followed by `show_file(".gitignore")`. CP/CR.
 
 ```{r wisdom-4}
 question_text(NULL,
@@ -938,7 +938,7 @@ library(tidybayes)
 Add `library(brms)` and `library(tidybayes)` to `five-parameters.qmd`. `Command/Ctrl + Shift + K`. At the Console, run:
 
 ```
-tutorial.helpers::show_file("five-parameters.qmd", pattern = "brms|tidybayes")
+show_file("five-parameters.qmd", pattern = "brms|tidybayes")
 ```
 
 CP/CR.
@@ -1123,7 +1123,7 @@ To confirm, `Command/Ctrl + Shift + K` again. It should be quick.
 At the Console, run:
 
 ```
-tutorial.helpers::show_file("five-parameters.qmd", start = -8)
+show_file("five-parameters.qmd", start = -8)
 ```
 
 CP/CR.
@@ -1271,7 +1271,7 @@ Update `five-parameters.qmd`. First, add `library(gtsummary)` to the `setup` cod
 At the Console, run:
 
 ```
-tutorial.helpers::show_file(".qmd", start = -8)
+show_file(".qmd", start = -8)
 ```
 
 CP/CR.
@@ -1595,7 +1595,7 @@ Create a new code chunk in `five-parameters.qmd`. Label it with `#| label: plot`
 At the Console, run:
 
 ```
-tutorial.helpers::show_file("five-parameters.qmd", start = -8)
+show_file("five-parameters.qmd", start = -8)
 ```
 
 CP/CR.
@@ -1649,7 +1649,7 @@ Rearrange the material in `five-parameters.qmd` so that the order is graphic, pa
 At the Console, run:
 
 ```
-tutorial.helpers::show_file("five-parameters.qmd")
+show_file("five-parameters.qmd")
 ```
 
 CP/CR.


### PR DESCRIPTION
All this PR does change the `tutorial.helpers::` in various places to a `library(tutorial.helpers)` too prevent confusion and unknown errors. This only caused confusion to one student in the Discord channel so it seems **extremely** minor and shouldn't affect the functionality of the tutorial in any noticeable way.